### PR TITLE
Upgrades jQuery to 3.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,15 +8,15 @@
     "components"
   ],
   "dependencies": {
-    "jquery": "3.0.0",
-    "underscore": "^1.6.0",
-    "moment": "^2.5.0"
+    "jquery": "~3.0.0",
+    "underscore": "~1.8.3",
+    "moment": "~2.10.3"
   },
   "devDependencies": {
     "expectations": "~0.2.6",
-    "requirejs": ">=2",
-    "mocha": ">=1.20.1",
-    "bootstrap": "2.1.1",
-    "sinon": ">=1.7.3"
+    "requirejs": "~2.1.14",
+    "mocha": "~1.20.1",
+    "bootstrap": "~2.1.1",
+    "sinon": "1.17.4"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "components"
   ],
   "dependencies": {
-    "jquery": "^1.7.2",
+    "jquery": "3.0.0",
     "underscore": "^1.6.0",
     "moment": "^2.5.0"
   },

--- a/lib/timepicker/timepicker.js
+++ b/lib/timepicker/timepicker.js
@@ -440,7 +440,7 @@
 
 
     // custom selector
-    $.expr[':'].timepicker = function (elem) {
+    $.expr.pseudos.timepicker = function (elem) {
         return $(elem).data('timepicker') !== undefined;
     };
 

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "bower": "^1.3.12",
-    "mocha": "~1.7.4",
-    "phantomjs": "^1.9.10",
-    "serve": "*",
-    "testem": "^0.6.20"
+    "bower": "~1.7.9",
+    "mocha": "~2.5.3",
+    "serve": "~1.4.0",
+    "testem": "~1.9.0",
+    "phantomjs-prebuilt": "~2.1.7"
   },
   "optionalDependencies": {}
 }


### PR DESCRIPTION
This PR updates jQuery to 3.0.0 and change the deprecated `jQuery.expr[':']` to `jQuery.expr.pseudos` as per https://github.com/jquery/jquery-migrate/blob/master/warnings.md#jqmigrate-jqueryexpr-is-jqueryexprpseudos

I also took the opportunity to update libs and pin their versions correctly

### Tests

Besides the unit tests here, I have also tested the changes by consuming it in our main app and confirming the timepicker (inside daterangepicker) continued working as expected 😉 